### PR TITLE
Add check for docker version to ensure the correct prune command

### DIFF
--- a/Unraid_check_docker_script.sh
+++ b/Unraid_check_docker_script.sh
@@ -20,9 +20,15 @@ echo
 echo "---------------------------------------------------------------------------------"
 echo
 if [ "$remove_unconnected_volumes" == "yes"  ] ; then
-    echo "Removing unconnected docker volumes"
-    echo
-    docker volume prune -f
+  echo "Removing unconnected docker volumes"
+  echo
+  # Check if docker major version is 23 or greater to ensure we use the correct command
+  docker_version=`(docker --version | awk -F'[ ,]+' '{print $3}' | awk -F'.' '{print $1}')`
+  if [ "$docker_version" -ge 23 ] ; then
+      docker volume prune -f --all
+    else
+      docker volume prune -f
+    fi
   else
     echo "Not removing unconnected docker volumes (this can be set in script if you want to)"
   fi


### PR DESCRIPTION
# Description

The `docker volume prune` command does work the same way in Docker version 23.0 or greater, in that it now only removes anonymous volumes by default. unRAID version 6.12.8 updated Docker to version 24.0.9 (see [release notes](https://docs.unraid.net/unraid-os/release-notes/6.12.8/)). To restore the original functionality one can add the `--all` flag to the command, which removes all dangling volumes. 

This change adds a check to Docker version and modifies the `docker volume prune` command if using version 23.0 or greater.  

See [Docker CLI issue #4028](https://github.com/docker/cli/issues/4028) for details.

# How Has This Been Tested?

This has been tested on unRAID version 6.12.8 running Docker version 24.0.9, and also on a non-unRAID Linux machine running Docker version 20.10.25.